### PR TITLE
fix: Push args (apiKey, source, etc) now working

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -35,6 +35,7 @@ export async function publish(
     'nuget',
     'push',
     resolved.asset,
+    ...args,
     ...resolved.pushArguments,
   ], options);
 


### PR DESCRIPTION
Fixes a bug within the publish step where the arguments (such as apiKey, source) doesn't get added properly when specified.